### PR TITLE
Update Python files to work in Python 3 (still work with 2).

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ The following system packages are necessary before setup will work.
 
 ### Python 2
 The python2 dev package must be installed for pip to be able to compile the Python packages in requirements-python2.txt, otherwise the packages will not install (may work if "wheel" is installed if a binary wheel for Python 2 is still available on pypi).
+- NOTE: Python 2 is deprecated, so distros based on debian bookworm and possibly other base distros or later ones do not have a "python" command. Therefore, the "shebang" in the Python scripts is "python3". However, the scripts were designed with Python 2 in mind and may work on older systems by running "python <scriptname>" or "python2 <scriptname>" to prevent your shell from trying to call python3.
 
 #### Debian-based (such as Ubuntu)
 - python2-dev

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,27 @@
+# xdg-tools
+Utilize XDG-based system packages such as to discover icon names or run a ".desktop" file.
+
+
+## Requirements
+The following system packages are necessary before setup will work.
+
+### Python 2
+The python2 dev package must be installed for pip to be able to compile the Python packages in requirements-python2.txt, otherwise the packages will not install (may work if "wheel" is installed if a binary wheel for Python 2 is still available on pypi).
+
+#### Debian-based (such as Ubuntu)
+- python2-dev
+
+### Python 3
+
+#### RPM-based (such as Fedora)
+- gtk-devel
+
+#### Debian-based distros (such as Ubuntu)
+- libgtk-3-dev
+
+
+## Using icon names
+An icon name obtained using `xdg-icon-list` such as "folder" can be used as follows in an XDG ".desktop" file's "[Desktop Entry]" section:
+```
+Icon=folder
+```

--- a/requirements-python2.txt
+++ b/requirements-python2.txt
@@ -1,0 +1,1 @@
+PyGObject

--- a/xdg-desktop-run
+++ b/xdg-desktop-run
@@ -16,21 +16,47 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program. See <http://www.gnu.org/licenses/gpl.html>
 
-"""Run a .desktop file, executing its application"""
-# from __future__ import print_function
+"""
+Run a .desktop file, executing its application
+
+Usage:
+xdg-desktop-run DESKTOP-FILE [ARGS...]
+
+"""
+from __future__ import print_function
 
 import sys
 from gi.repository import Gio
 
-if __name__ == "__main__":
+def usage():
+	print(__doc__, file=sys.stderr)
 
+def main():
+	if len(sys.argv) < 2:
+		usage()
+		print("Error: Missing DESKTOP-FILE argument.",
+			  file=sys.stderr)
+		return 1
+
+	desktop = sys.argv[1]
+	uris = sys.argv[2:]
+	msg = ""
 	try:
-		desktop = sys.argv[1]
-		uris = sys.argv[2:]
-	except:
-		sys.stderr.write("Missing DESKTOP-FILE argument.\n"
-			"Usage: xdg-desktop-run DESKTOP-FILE [ARGS...]\n")
-		sys.exit(1)
+		info = Gio.DesktopAppInfo.new_from_filename(desktop)
+	except TypeError as ex:
+		info = None
+		if "NULL" in str(ex).upper():
+			info = None
+			msg = " {}".format(ex)  # "constructor returned NULL"
+			# (such as if shortcut has no Desktop Entry section)
+		else:
+			raise
+	if not info:
+		print("Error: The shortcut appears to be invalid"
+		      " (may be missing [Desktop Entry] section)."+msg)
+		return 2
+	rc = info.launch_uris(uris, None)
+	return rc
 
-	sys.exit(Gio.DesktopAppInfo.new_from_filename(desktop).launch_uris(
-		uris, None))
+if __name__ == "__main__":
+	sys.exit(main())

--- a/xdg-desktop-run
+++ b/xdg-desktop-run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 #    Copyright (C) 2013 Rodrigo Silva (MestreLion) <linux@rodrigosilva.com>

--- a/xdg-desktop-run
+++ b/xdg-desktop-run
@@ -27,6 +27,7 @@ from __future__ import print_function
 
 import sys
 from gi.repository import Gio
+# ^ See system requirements in readme.md.
 
 def usage():
 	print(__doc__, file=sys.stderr)

--- a/xdg-desktop-run
+++ b/xdg-desktop-run
@@ -17,6 +17,7 @@
 #    along with this program. See <http://www.gnu.org/licenses/gpl.html>
 
 """Run a .desktop file, executing its application"""
+# from __future__ import print_function
 
 import sys
 from gi.repository import Gio

--- a/xdg-icon-list
+++ b/xdg-icon-list
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 import sys
 import gi
+# ^ See system requirements in readme.md.
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 

--- a/xdg-icon-list
+++ b/xdg-icon-list
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 #    Copyright (C) 2013 Rodrigo Silva (MestreLion) <linux@rodrigosilva.com>

--- a/xdg-icon-list
+++ b/xdg-icon-list
@@ -27,6 +27,7 @@ def usage(ok=True):
 	sys.stderr.write("Usage: xdg-icon-list [ICONPREFIX]\n")
 	sys.exit(0 if ok else 1)
 
+
 if len(sys.argv) > 2:
 	usage(False)
 

--- a/xdg-icon-list
+++ b/xdg-icon-list
@@ -17,6 +17,7 @@
 #    along with this program. See <http://www.gnu.org/licenses/gpl.html>
 
 """List all regitered icon names matching an optional prefix"""
+from __future__ import print_function
 
 import sys
 import gi
@@ -42,4 +43,4 @@ if name in ('-h', '--help'):
 theme = Gtk.IconTheme.get_default()
 for icon in sorted(theme.list_icons(None)):
 	if not name or icon.startswith(name):
-		print icon
+		print(icon)

--- a/xdg-icon-path
+++ b/xdg-icon-path
@@ -19,15 +19,20 @@
 """Print chosen file path of a registered icon name for a given size"""
 from __future__ import print_function
 import sys
+use_gi = False
 if sys.version_info.major < 3:
-    import gtk
+    # import gtk
+    import gi
+    # ^ See system requirements in readme.md.
+    gi.require_version('Gtk', '3.0')
+    from gi.repository import Gtk
+    use_gi = True
 else:
     import gi
-    # gi.require_version('Gtk', '3.0)
+    # ^ See system requirements in readme.md.
+    gi.require_version('Gtk', '3.0')
+    use_gi = True
     from gi.repository import Gtk
-    # requires
-    # - gtk-devel on fedora
-    # - libgtk-3-dev (?) on Debian-based distros such as Ubuntu
 
 try:
     icon = sys.argv[1]
@@ -41,7 +46,8 @@ try:
 except:
     size = 48
 
-if sys.version_info.major < 3:
+# if sys.version_info.major < 3:
+if not use_gi:
     icon_theme = gtk.icon_theme_get_default()
 else:
     icon_theme = Gtk.IconTheme.get_default()

--- a/xdg-icon-path
+++ b/xdg-icon-path
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 #    Copyright (C) 2013 Rodrigo Silva (MestreLion) <linux@rodrigosilva.com>

--- a/xdg-icon-path
+++ b/xdg-icon-path
@@ -21,21 +21,21 @@
 import gtk, sys
 
 try:
-	icon = sys.argv[1]
+    icon = sys.argv[1]
 except:
-	sys.stderr.write("Missing ICON argument.\n"
-	                 "Usage: xdg-icon-path ICON [SIZE]\n")
-	sys.exit(1)
+    sys.stderr.write("Missing ICON argument.\n"
+                     "Usage: xdg-icon-path ICON [SIZE]\n")
+    sys.exit(1)
 
 try:
-	size = sys.argv[2]
+    size = sys.argv[2]
 except:
-	size = 48
+    size = 48
 
 
 icon_theme = gtk.icon_theme_get_default()
 icon_info = icon_theme.lookup_icon(sys.argv[1], int(size), 0)
 if icon_info:
-	print icon_info.get_filename()
+    print icon_info.get_filename()
 else:
-	print "icon not found"
+    print "icon not found"

--- a/xdg-icon-path
+++ b/xdg-icon-path
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #    Copyright (C) 2013 Rodrigo Silva (MestreLion) <linux@rodrigosilva.com>
@@ -17,7 +17,7 @@
 #    along with this program. See <http://www.gnu.org/licenses/gpl.html>
 
 """Print chosen file path of a registered icon name for a given size"""
-
+from __future__ import print_function
 import gtk, sys
 
 try:
@@ -36,6 +36,6 @@ except:
 icon_theme = gtk.icon_theme_get_default()
 icon_info = icon_theme.lookup_icon(sys.argv[1], int(size), 0)
 if icon_info:
-    print icon_info.get_filename()
+    print(icon_info.get_filename())
 else:
-    print "icon not found"
+    print("icon not found")

--- a/xdg-icon-path
+++ b/xdg-icon-path
@@ -18,7 +18,16 @@
 
 """Print chosen file path of a registered icon name for a given size"""
 from __future__ import print_function
-import gtk, sys
+import sys
+if sys.version_info.major < 3:
+    import gtk
+else:
+    import gi
+    # gi.require_version('Gtk', '3.0)
+    from gi.repository import Gtk
+    # requires
+    # - gtk-devel on fedora
+    # - libgtk-3-dev (?) on Debian-based distros such as Ubuntu
 
 try:
     icon = sys.argv[1]
@@ -32,8 +41,10 @@ try:
 except:
     size = 48
 
-
-icon_theme = gtk.icon_theme_get_default()
+if sys.version_info.major < 3:
+    icon_theme = gtk.icon_theme_get_default()
+else:
+    icon_theme = Gtk.IconTheme.get_default()
 icon_info = icon_theme.lookup_icon(sys.argv[1], int(size), 0)
 if icon_info:
     print(icon_info.get_filename())

--- a/xdg-icon-paths
+++ b/xdg-icon-paths
@@ -24,24 +24,24 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 try:
-	name = sys.argv[1]
+    name = sys.argv[1]
 except:
-	sys.stderr.write("Missing ICON argument.\n"
-	                 "Usage: xdg-icon-paths ICON\n")
-	sys.exit(1)
+    sys.stderr.write("Missing ICON argument.\n"
+                     "Usage: xdg-icon-paths ICON\n")
+    sys.exit(1)
 
 theme = Gtk.IconTheme.get_default()
 
 if not theme.has_icon(name):
-	print "icon not found"
-	sys.exit(1)
+    print "icon not found"
+    sys.exit(1)
 
 icons = []
 # theme.get_icon_sizes() is *very* buggy. Try it with gimp, firefox, etc
 for size in xrange(513):
-	icon = theme.lookup_icon(name, size, 0).get_filename()
-	if icon not in icons:
-		icons.append(icon)
+    icon = theme.lookup_icon(name, size, 0).get_filename()
+    if icon not in icons:
+        icons.append(icon)
 
 for icon in icons:
-	print icon
+    print icon

--- a/xdg-icon-paths
+++ b/xdg-icon-paths
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 #    Copyright (C) 2013 Rodrigo Silva (MestreLion) <linux@rodrigosilva.com>

--- a/xdg-icon-paths
+++ b/xdg-icon-paths
@@ -20,6 +20,7 @@
 from __future__ import print_function
 import sys
 import gi
+# ^ See system requirements in readme.md.
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 

--- a/xdg-icon-paths
+++ b/xdg-icon-paths
@@ -17,7 +17,7 @@
 #    along with this program. See <http://www.gnu.org/licenses/gpl.html>
 
 """Print chosen file path of a registered icon name for a given size"""
-
+from __future__ import print_function
 import sys
 import gi
 gi.require_version('Gtk', '3.0')
@@ -33,15 +33,15 @@ except:
 theme = Gtk.IconTheme.get_default()
 
 if not theme.has_icon(name):
-    print "icon not found"
+    print("icon not found")
     sys.exit(1)
 
 icons = []
 # theme.get_icon_sizes() is *very* buggy. Try it with gimp, firefox, etc
-for size in xrange(513):
+for size in range(513):
     icon = theme.lookup_icon(name, size, 0).get_filename()
     if icon not in icons:
         icons.append(icon)
 
 for icon in icons:
-    print icon
+    print(icon)


### PR DESCRIPTION
- Adapt usage depending on whether Python 2 or 3 has been detected.
- The python files now are tested and working in both Python 3.
  - ~~Therefore, the shebang is changed to use `python` (the system's default python will be used).~~
  - :edit: (2024-08-21) I reverted the shebangs to use python3 since "python-is-python3" is not installed by default on Debian bookworm and derivatives, nor is python2, so there is no "python" command (only "python3"). Python 2 users will have to run `python2 <scriptname>` or make a shell scripts containing that to launch the scripts on older systems.